### PR TITLE
Update pihole-cloudsync

### DIFF
--- a/pihole-cloudsync
+++ b/pihole-cloudsync
@@ -101,7 +101,7 @@ version() {
 export_tables() {
 	# Export from Gravity database
 	for tab in "${tables[@]}"; do
-		${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM \"${tab}\"" >"${tab}.csv"
+        ${SUDO} sqlite3 "${gravity_db}" -header -csv "SELECT * FROM \"${tab}\"" >"${personal_git_dir}/${tab}.csv"
 	done
 }
 


### PR DESCRIPTION
This fix ensures that tables are exported to the personal git directory, not the directory from which the script was run.  Prior to this, if the script was not run from the personal git directory, the exported csv files would not be synced to secondary piholes as they were not created in the correct directory to be synced.